### PR TITLE
Added files property to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
   ],
   "author": "Blaine Bublitz <blaine@iceddev.com> (http://iceddev.com/)",
   "license": "MIT",
+  "files": [
+    "index.js"
+  ],
   "bugs": {
     "url": "https://github.com/phated/pick-values/issues"
   },


### PR DESCRIPTION
This will make sure the `test` directory is not installed in the `node_modules` directory. It keeps the footprint of the installed module smaller.
